### PR TITLE
fix/dualmode_board_remaining

### DIFF
--- a/src/components/menus/game-over/index.tsx
+++ b/src/components/menus/game-over/index.tsx
@@ -16,16 +16,21 @@ const GameOverMenu: FC<GameOverMenuProps> = observer(props => {
   return (
     <InfoModal visible={props.visible}>
       <Title />
-      {store.gameMode === GameMode.SinglePlayer
-        ? (
-          <Title content={`Score: ${store.scoreP1}`} />
-        )
-        : (
-          <Title content={`Player ${store.winner === Player.Player1 ? 1 : 2} won!`} />
-        )}
+      {store.gameMode === GameMode.SinglePlayer ? (
+        <Title content={`Score: ${store.scoreP1}`} />
+      ) : (
+        <Title content={`Player ${store.winner === Player.Player1 ? 1 : 2} won!`} />
+      )}
       <div className="ButtonContainer">
         <Button title="PLAY AGAIN" onClick={store.launchGame} fullWidth />
-        <Button title="BACK TO MAIN" onClick={store.stopGame} fullWidth />
+        <Button
+          title="BACK TO MAIN"
+          onClick={() => {
+            store.gameMode = GameMode.SinglePlayer;
+            store.stopGame();
+          }}
+          fullWidth
+        />
       </div>
     </InfoModal>
   );

--- a/src/components/menus/pause/index.tsx
+++ b/src/components/menus/pause/index.tsx
@@ -25,7 +25,14 @@ const PauseMenu: FC<PauseMenuProps> = observer(props => {
             <Button title="LOAD" onClick={store.loadParty} fullWidth />
           </>
         )}
-        <Button title="BACK TO MAIN" onClick={store.stopGame} fullWidth />
+        <Button
+          title="BACK TO MAIN"
+          onClick={() => {
+            store.gameMode = GameMode.SinglePlayer;
+            store.stopGame();
+          }}
+          fullWidth
+        />
       </div>
     </InfoModal>
   );


### PR DESCRIPTION
If you play 2player's mode then try auto mode, the game board is set to dual mode's board.

It seems that it's happening because you set store.gameMode to GameMode.DualPlayer when you enter the 2player's mode

but not resetting it back to GameMode.SinglePlayer when you getting out of it.

There might be a better solution, but I simply added two lines of code to set the game mode back to single player when getting out of the dual mode play.